### PR TITLE
BUG: Fix resample in SegPostProcessCLP

### DIFF
--- a/Modules/CLI/SegPostProcessCLP/SegPostProcessCLP.cxx
+++ b/Modules/CLI/SegPostProcessCLP/SegPostProcessCLP.cxx
@@ -533,6 +533,7 @@ int main( int argc, char * argv[] )
       resampleFilter->SetSize(size);
       resampleFilter->SetOutputSpacing(spacing);
       resampleFilter->SetOutputOrigin(image->GetOrigin() );
+      resampleFilter->SetOutputDirection(image->GetDirection());
       resampleFilter->SetTransform(transform.GetPointer() );
       resampleFilter->SetInterpolator(interpolFunction.GetPointer() );
       resampleFilter->Update();
@@ -585,6 +586,7 @@ int main( int argc, char * argv[] )
       resampleFilter->SetSize(size);
       resampleFilter->SetOutputSpacing(spacing);
       resampleFilter->SetOutputOrigin(image->GetOrigin() );
+      resampleFilter->SetOutputDirection(image->GetDirection());
       resampleFilter->SetTransform(transform.GetPointer() );
       resampleFilter->SetInterpolator(interpolFunction.GetPointer() );
       resampleFilter->Update();


### PR DESCRIPTION
It was missing setting the direction for the output image.

Fix #40
Fix https://github.com/Kitware/SlicerSALT/issues/123