### PR TITLE
Fix build against VTK9

### DIFF
--- a/Modules/CLI/GenParaMeshCLP/vtkPolyDataToitkMesh.cxx
+++ b/Modules/CLI/GenParaMeshCLP/vtkPolyDataToitkMesh.cxx
@@ -74,7 +74,11 @@ vtkPolyDataToitkMesh
   //
   vtkSmartPointer<vtkCellArray> triangleStrips = m_PolyData->GetStrips();
 
-  vtkIdType  * cellPoints;
+#if VTK_MAJOR_VERSION >= 9 || (VTK_MAJOR_VERSION >= 8 && VTK_MINOR_VERSION >= 90)
+  const vtkIdType*  cellPoints;
+#else
+  vtkIdType*  cellPoints;
+#endif
   vtkIdType    numberOfCellPoints;
 
   //

--- a/Modules/CLI/MetaMeshTools/MeshMath.cxx
+++ b/Modules/CLI/MetaMeshTools/MeshMath.cxx
@@ -4042,8 +4042,8 @@ int main(int argc, const char * *argv)
   else if( avgOneKWMOn ) // bp2009
     {
     char     line[70];
-    ifstream input;
-    ofstream output;
+    std::ifstream input;
+    std::ofstream output;
     int      NPoints;
     float    value;
     float    sum = 0;
@@ -4078,8 +4078,8 @@ int main(int argc, const char * *argv)
   else if( minOneKWMOn ) // bp2009
     {
     char     line[70];
-    ifstream input;
-    ofstream output;
+    std::ifstream input;
+    std::ofstream output;
     float    value;
     //char *   aux;
     float    minOne = 9999999;
@@ -4113,8 +4113,8 @@ int main(int argc, const char * *argv)
   else if( maxOneKWMOn ) // bp2009
     {
     char     line[70];
-    ifstream input;
-    ofstream output;
+    std::ifstream input;
+    std::ofstream output;
     float    value;
     //char *   aux;
     float    maxOne = 0;
@@ -4148,8 +4148,8 @@ int main(int argc, const char * *argv)
   else if( medianOneKWMOn ) // bp2009
     {
     char     line[70];
-    ifstream input;
-    ofstream output;
+    std::ifstream input;
+    std::ofstream output;
     int      NPoints;
     float    value;
     char *   aux;
@@ -4192,8 +4192,8 @@ int main(int argc, const char * *argv)
   else if( per1OneKWMOn ) // bp2009
     {
     char     line[70];
-    ifstream input;
-    ofstream output;
+    std::ifstream input;
+    std::ofstream output;
     int      NPoints;
     float    value;
     char *   aux;
@@ -4237,8 +4237,8 @@ int main(int argc, const char * *argv)
   else if( per99OneKWMOn ) // bp2009
     {
     char     line[70];
-    ifstream input;
-    ofstream output;
+    std::ifstream input;
+    std::ofstream output;
     int      NPoints;
     float    value;
     char *   aux;
@@ -4330,8 +4330,8 @@ int main(int argc, const char * *argv)
     {
     char     line[70];
     char     line2[70];
-    ifstream inputROI, inputFile;
-    ofstream output;
+    std::ifstream inputROI, inputFile;
+    std::ofstream output;
     int      NPoints, Dim;
     float    valueROI, valueFile;
     char *   aux;
@@ -4454,7 +4454,7 @@ int main(int argc, const char * *argv)
 
     // *** START PARSING KWMeshVisu file
     char     line[70];
-    ifstream input;
+    std::ifstream input;
     int      NPoints, NDimension;
     char *   aux;
     input.open(files[0], ios::in);
@@ -4543,7 +4543,7 @@ int main(int argc, const char * *argv)
 
     // *** START PARSING FreeSurfer file
     char     line[70];
-    ifstream input;
+    std::ifstream input;
     int      NPoints;
     input.open(files[0], ios::in);
 

--- a/Modules/CLI/MetaMeshTools/STL2Meta.cxx
+++ b/Modules/CLI/MetaMeshTools/STL2Meta.cxx
@@ -80,7 +80,11 @@ int main(int argc, const char * *argv)
   //
   vtkSmartPointer<vtkCellArray> triangleStrips = polyData->GetStrips();
 
-  vtkIdType * cellPoints;
+#if VTK_MAJOR_VERSION >= 9 || (VTK_MAJOR_VERSION >= 8 && VTK_MINOR_VERSION >= 90)
+  const vtkIdType*  cellPoints;
+#else
+  vtkIdType*  cellPoints;
+#endif
   vtkIdType   numberOfCellPoints;
 
   //

--- a/Modules/CLI/MetaMeshTools/vtkPolyDataToitkMesh.cxx
+++ b/Modules/CLI/MetaMeshTools/vtkPolyDataToitkMesh.cxx
@@ -70,7 +70,11 @@ vtkPolyDataToitkMesh
   //
   vtkSmartPointer<vtkCellArray> triangleStrips = m_PolyData->GetStrips();
 
+#if VTK_MAJOR_VERSION >= 9 || (VTK_MAJOR_VERSION >= 8 && VTK_MINOR_VERSION >= 90)
+  const vtkIdType*  cellPoints;
+#else
   vtkIdType*  cellPoints;
+#endif
   vtkIdType   numberOfCellPoints;
 
   //

--- a/Modules/CLI/ParaToSPHARMMeshCLP/vtkPolyDataToitkMesh.cxx
+++ b/Modules/CLI/ParaToSPHARMMeshCLP/vtkPolyDataToitkMesh.cxx
@@ -70,7 +70,11 @@ vtkPolyDataToitkMesh
   //
   vtkSmartPointer<vtkCellArray> triangleStrips = m_PolyData->GetStrips();
 
+#if VTK_MAJOR_VERSION >= 9 || (VTK_MAJOR_VERSION >= 8 && VTK_MINOR_VERSION >= 90)
+  const vtkIdType*  cellPoints;
+#else
   vtkIdType*  cellPoints;
+#endif
   vtkIdType   numberOfCellPoints;
 
   //


### PR DESCRIPTION
This pull request is intended to address issues reported in
https://slicer.cdash.org/index.php?project=SlicerPreview&date=2021-05-18&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=SPHARM-PDM

Slicer migration guide has been updated accordingly.

See https://www.slicer.org/w/index.php?title=Documentation/Nightly/Developers/Tutorials/MigrationGuide#Slicer_5.0:_Supporting_both_VTK_8.0_and_VTK_9.0