### PR TITLE
COMP: Ensure headers like "stdlib.h" can be found on macOS when building LAPACK

### DIFF
--- a/SuperBuild.cmake
+++ b/SuperBuild.cmake
@@ -39,7 +39,7 @@ set(${extension_name}_SOURCE_DIR "${CMAKE_BINARY_DIR}/${extension_name}")
 FetchContent_Populate(${extension_name}
   SOURCE_DIR     ${${extension_name}_SOURCE_DIR}
   GIT_REPOSITORY ${EP_GIT_PROTOCOL}://github.com/NIRALUser/GROUPS.git
-  GIT_TAG        d73b2f7b42296e8f22d24ea4adcb06b9ccf5b9da # master
+  GIT_TAG        9a72008c6cbffa036e13c2dee18e3a2a23bc5d7c # master
   GIT_PROGRESS   1
   QUIET
   )

--- a/SuperBuild/External_LAPACK.cmake
+++ b/SuperBuild/External_LAPACK.cmake
@@ -156,7 +156,11 @@ if(NOT DEFINED LAPACK_DIR AND NOT ${SUPERBUILD_TOPLEVEL_PROJECT}_USE_SYSTEM_LAPA
       # Failure was observed when using gfortran_osx-64 from conda.
       list(APPEND EXTERNAL_PROJECT_OPTIONAL_CMAKE_CACHE_ARGS
         -DCMAKE_OSX_ARCHITECTURES:STRING=
-        -DCMAKE_OSX_SYSROOT:PATH=
+        # Pass SYSROOT to ensure header like "stdlib.h" can be found on macOS at least >= 10.15
+        # when using the full path to the compiler.
+        # For example, "/Applications/Xcode_11.7.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/cc"
+        # See https://andreasfertig.blog/2021/02/clang-and-gcc-on-macos-catalina-finding-the-include-paths/
+        #-DCMAKE_OSX_SYSROOT:PATH=
         -DCMAKE_OSX_DEPLOYMENT_TARGET:STRING=
         )
     endif()


### PR DESCRIPTION
This commit fixes errors like the following:

```
  [...]
  /Applications/Xcode_11.7.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/cc  \
    -I/path/to/SPHARM-PDM-build/LAPACK/LAPACKE/include \
    -I/path/to/SPHARM-PDM-build/LAPACK-build/include -O3 -DNDEBUG \
    -fPIC -MD -MT LAPACKE/CMakeFiles/lapacke.dir/src/lapacke_cbbcsd.c.o -MF \
    CMakeFiles/lapacke.dir/src/lapacke_cbbcsd.c.o.d -o CMakeFiles/lapacke.dir/src/lapacke_cbbcsd.c.o \
    -c /path/to/SPHARM-PDM-build/LAPACK/LAPACKE/src/lapacke_cbbcsd.c

  In file included from /path/to/SPHARM-PDM-build/LAPACK/LAPACKE/src/lapacke_cbbcsd.c:34:
  In file included from /path/to/SPHARM-PDM-build/LAPACK/LAPACKE/include/lapacke_utils.h:37:
  /path/to/SPHARM-PDM-build/LAPACK/LAPACKE/include/lapacke.h:44:10: fatal error: 'stdlib.h' file not found
```

Specifying the `CMAKE_OSX_SYSROOT` option ensures the `-isysroot` parameter is
is passed to successfully look up the headers:

```
  /Applications/Xcode_11.7.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/cc  \
    -I/path/to/SPHARM-PDM-build/LAPACK/LAPACKE/include \
    -I/path/to/SPHARM-PDM-build/LAPACK-build/include -O3 -DNDEBUG \
    -isysroot /Applications/Xcode_11.7.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.15.sdk \
    -fPIC -MD -MT LAPACKE/CMakeFiles/lapacke.dir/src/lapacke_cbbcsd.c.o -MF \
    CMakeFiles/lapacke.dir/src/lapacke_cbbcsd.c.o.d -o CMakeFiles/lapacke.dir/src/lapacke_cbbcsd.c.o \
    -c /path/to/SPHARM-PDM-build/LAPACK/LAPACKE/src/lapacke_cbbcsd.c
```

References:
* https://andreasfertig.blog/2021/02/clang-and-gcc-on-macos-catalina-finding-the-include-paths/

List of GROUPS changes:

```
$ git shortlog d73b2f7b4..9a72008c6 --no-merges
Jean-Christophe Fillion-Robin (1):
      COMP: Ensure headers like "stdlib.h" can be found on macOS when building LAPACK
```