### PR TITLE
COMP: Remove the register keyword

### DIFF
--- a/Libraries/Shape/Algorithms/EqualAreaParametricMeshNewtonIterator.cxx
+++ b/Libraries/Shape/Algorithms/EqualAreaParametricMeshNewtonIterator.cxx
@@ -303,7 +303,7 @@ int EqualAreaParametricMeshNewtonIterator::check_constraints(int n_equal, int n_
   //int worst = -1;
   for( act_i = n_equal + n_active; act_i-- > 0; )   // also over positive inequalities(?)
     {
-    register double increase = sqr(c_hat_try[act_i]) - sqr(c_hat[act_i]);
+    double increase = sqr(c_hat_try[act_i]) - sqr(c_hat[act_i]);
     if( increase > badness )
       {
       badness = increase;


### PR DESCRIPTION
With C++ 17, the register keyword has been removed.

The register keyword was a hint to the compiler that the variable will be
heavily used and that you recommend it be kept in a processor register
if possible.

Build error on macOS: https://slicer.cdash.org/viewBuildError.php?buildid=2734976