### PR TITLE
BUG: Procrustes-aligned output has parametric scalar data if enabled.

### DIFF
--- a/Modules/CLI/ParaToSPHARMMeshCLP/ParaToSPHARMMeshCLP.cxx
+++ b/Modules/CLI/ParaToSPHARMMeshCLP/ParaToSPHARMMeshCLP.cxx
@@ -1039,6 +1039,78 @@ int main( int argc, char * argv[] )
       std::cout << "procalign" << std::endl;
       itkMeshTovtkPolyData ITKVTKConverter3;
       ITKVTKConverter3.SetInput(RegisteredMesh);
+
+    if( writePara )
+      {
+          MeshType *             _paraMesh = meshsrc->GetOutputParaMesh();
+          PointsContainerPointer paraPoints = _paraMesh->GetPoints();
+          // DIMENSION = 1 ; NUMBER_OF_POINTS ; TYPE = Scalar
+            {
+              // write phi
+              int nvert = paraPoints->Size();
+              vtkSmartPointer<vtkDoubleArray> array = vtkSmartPointer<vtkDoubleArray>::New();
+              array->SetName("_paraPhi");
+
+              for( int i = 0; i < nvert; i++ )
+              {
+                  PointType curPoint =  paraPoints->GetElement(i);
+                  double    phi = atan2(curPoint[1], curPoint[0]) + M_PI; // 0 .. 2 * M_PI
+                  array->InsertNextValue(phi);
+              }
+              ITKVTKConverter3.GetOutput()->GetPointData()->AddArray(array);
+            }
+            {
+              // write phi half
+                int nvert = paraPoints->Size();
+                vtkSmartPointer<vtkDoubleArray> array = vtkSmartPointer<vtkDoubleArray>::New();
+                array->SetName("_paraPhiHalf");
+                for( int i = 0; i < nvert; i++ )
+                {
+                  PointType curPoint =  paraPoints->GetElement(i);
+                  double    phi = atan2(curPoint[1], curPoint[0]) + M_PI;
+                  if( phi > M_PI )
+                  {
+                    phi = 2 * M_PI - phi;       // 0 .. M_PI ..0
+                  }
+                  array->InsertNextValue(phi);
+                }
+                ITKVTKConverter3.GetOutput()->GetPointData()->AddArray(array);
+            }
+            {
+                // write theta
+                int nvert = paraPoints->Size();
+                vtkSmartPointer<vtkDoubleArray> array = vtkSmartPointer<vtkDoubleArray>::New();
+                array->SetName("_paraTheta");
+                for( int i = 0; i < nvert; i++ )
+                {
+                  PointType curPoint =  paraPoints->GetElement(i);
+                  double    curTheta = atan(curPoint[2] / sqrt(curPoint[0] * curPoint[0] + curPoint[1] * curPoint[1]) ) + M_PI_2;
+                  //0 .. M_PI
+                  array->InsertNextValue(curTheta);
+                }
+                ITKVTKConverter3.GetOutput()->GetPointData()->AddArray(array);
+            }
+            {
+                // write theta/M_PI * (phi/M_PI/2 + 1)
+                int nvert = paraPoints->Size();
+                vtkSmartPointer<vtkDoubleArray> array = vtkSmartPointer<vtkDoubleArray>::New();
+                array->SetName("_paraMix");
+                for( int i = 0; i < nvert; i++ )
+                {
+                  PointType curPoint =  paraPoints->GetElement(i);
+                  double    phi = atan2(curPoint[1], curPoint[0]) + M_PI;
+                  if( phi > M_PI )
+                    {
+                    phi = 2 * M_PI - phi;            // 0 .. M_PI ..0
+                    }
+                  double curTheta = atan(curPoint[2] / sqrt(curPoint[0] * curPoint[0] + curPoint[1] * curPoint[1]) ) + M_PI_2;
+                  // 0 .. M_PI
+                  array->InsertNextValue(curTheta/ M_PI * ( phi / M_PI + 1));
+                }
+                ITKVTKConverter3.GetOutput()->GetPointData()->AddArray(array);
+            }
+      }
+
       vtkwriter->SetInputData(ITKVTKConverter3.GetOutput() );
       vtkwriter->SetFileName(outFileName.c_str() );
       vtkwriter->Write();


### PR DESCRIPTION
The code to copy the array values into scalars on the VTK output should probably be deduplicated - it is already duplicated twice for the `_SPHARM.vtk` and `_SPHARM_ellalign.vtk` outputs. In the interested of time I've just duplicated it again for this `_SPHARM_procalign.vtk` output...

For the SPHARM-PDM modularization refactor this should come for free since these steps are implemented as VTK filters and the scalars are automatically passed through... so I don't think this tech debt is too much.

Resolves #84.